### PR TITLE
Upgrade to rustfft "5.0.1" from "3.0.1"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["audio", "fft", "dsp", "fourier"]
 license = "GPL-3.0"
 
 [dependencies]
-rustfft = "3.0.1"
+rustfft = "5.0.1"
 apodize = "1.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This is just a port to the latest version of rustfft (5.0.1, which should support AVX).

Provided pvoc tests pass with no modifications.
The benchmark of my application, which uses pvoc, shows no regressions in performance, and also did not require any modification.

I considered adding some form of benchmark in this pull request, but I don't know what would be considered sufficient. (Maybe running the identity processor on a large input with varying fft sizes?)